### PR TITLE
New Client Add Link Prompt After Registration Success

### DIFF
--- a/client/src/components/Fields.js
+++ b/client/src/components/Fields.js
@@ -46,8 +46,13 @@ export class Fields extends Component {
       .then((res) => {
         this.setState({ loading: false });
         if (res.data.success === true) {
-          // Pop up with success modal
-          this.setState({showSuccessModal: true, classesWithoutLinks: res.data.unlinkedClasses});
+          // Only load success modal prompt when there is at least one unlinked class
+          if (res.data.unlinkedClasses.length > 0) {
+            // Pop up with success modal
+            this.setState({showSuccessModal: true, classesWithoutLinks: res.data.unlinkedClasses});
+          } else {
+            Message.success(`Successfully registered with ${email}`);
+          }
         } else {
           const errorMsg = (res && res.data.message && res.data.message.length>0) ? res.data.message : 'Unable to sign up at the moment. Please try again later'
           Message.error(errorMsg);

--- a/client/src/components/Fields.js
+++ b/client/src/components/Fields.js
@@ -3,6 +3,8 @@ import axios from 'axios';
 import { Form, Input, Button, Tooltip, message as Message } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 
+import Success from './Success';
+
 import './Fields.css';
 
 const layout = {
@@ -21,6 +23,7 @@ export class Fields extends Component {
       email: '',
       url: '',
       loading: false,
+      showSuccessModal: true
     };
   }
 
@@ -60,6 +63,7 @@ export class Fields extends Component {
 
   render() {
     return (
+      <React.Fragment>
       <Form
         {...layout}
         style={{ marginTop: '24px' }}
@@ -122,6 +126,12 @@ export class Fields extends Component {
           </Button>
         </Form.Item>
       </Form>
+      <Success 
+        visible={this.state.showSuccessModal}
+        classes={[{course: 'CS 3110', section: 'LEC 001'}, {course: 'INFO 1200', section: 'LEC 001'}]}
+        hideSuccess={() => this.setState({showSuccessModal: false})}
+      />
+      </React.Fragment>
     );
   }
 }

--- a/client/src/components/Fields.js
+++ b/client/src/components/Fields.js
@@ -23,7 +23,8 @@ export class Fields extends Component {
       email: '',
       url: '',
       loading: false,
-      showSuccessModal: true
+      showSuccessModal: false,
+      classesWithoutLinks: []
     };
   }
 
@@ -43,11 +44,10 @@ export class Fields extends Component {
     axios
       .get(`/api/schedule?email=${email}&id=${schedulerId}`)
       .then((res) => {
-        console.log(res);
         this.setState({ loading: false });
         if (res.data.success === true) {
-          Message.success(`Successfully signed up with ${this.state.email}`);
-          console.log(res.data.data);
+          // Pop up with success modal
+          this.setState({showSuccessModal: true, classesWithoutLinks: res.data.unlinkedClasses});
         } else {
           const errorMsg = (res && res.data.message && res.data.message.length>0) ? res.data.message : 'Unable to sign up at the moment. Please try again later'
           Message.error(errorMsg);
@@ -92,8 +92,8 @@ export class Fields extends Component {
           rules={[
             { required: true, message: 'URL field cannot be empty' },
             {
-              pattern: /(https?:\/\/)?(www\.)?classes\.cornell\.edu\/shared\/schedule\/(sp|su|fa|wi)[1-2][0-9]\/.......+/gi,
-              message: 'Please enter a valid shared schedule URL',
+              pattern: /(https?:\/\/)?(www\.)?classes\.cornell\.edu\/shared\/schedule\/sp20\/.......+/gi,
+              message: 'Please enter a valid Spring 2020 shared schedule URL',
             },
           ]}
         >
@@ -127,8 +127,9 @@ export class Fields extends Component {
         </Form.Item>
       </Form>
       <Success 
+        email={this.state.email}
         visible={this.state.showSuccessModal}
-        classes={[{course: 'CS 3110', section: 'LEC 001'}, {course: 'INFO 1200', section: 'LEC 001'}]}
+        classes={this.state.classesWithoutLinks}
         hideSuccess={() => this.setState({showSuccessModal: false})}
       />
       </React.Fragment>

--- a/client/src/components/Success.js
+++ b/client/src/components/Success.js
@@ -15,6 +15,7 @@ export function Success(props) {
 
         const addLinks = () => {
             const linksArray = Object.entries(links);
+            console.log(linksArray);
             if (linksArray.length > 0) {
                 const requestPromises = [];
 
@@ -32,7 +33,7 @@ export function Success(props) {
                 Promise.all(requestPromises).then(res => {
                     // Hide after clicking button and success
                     props.hideSuccess();
-                    Message.success(`Successfully added links to ${linksArray.length} ${linksArray.length === 1 ? 'Class' : 'Classes'}`);
+                    Message.success(`Successfully added links to ${linksArray.length} ${linksArray.length === 1 ? 'class' : 'classes'}`);
                 }).catch(err => {
                     Message.error(`Unable to add links right now. Try again later`);
                     console.log(err);
@@ -72,14 +73,13 @@ export function Success(props) {
                 name={`${classInfo.course}-${classInfo.section}`}
                 rules={[
                     {
-                      pattern: /\d{9,13}/gi,
+                      pattern: /[\w\d\-]{8,13}/gi,
                       message: 'Please enter a valid Zoom meeting ID',
                     },
                   ]}
                 >
                 <Input 
                     placeholder="9 - 11 digit meeting ID"
-                    type="number"
                     onChange={(e) => setLinks({...links, [`${classInfo.course}-${classInfo.section}`]: e.target.value })}
                 />
                 </Form.Item>

--- a/client/src/components/Success.js
+++ b/client/src/components/Success.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import axios from 'axios';
 import { Form, Input, Tooltip, Modal } from 'antd';
 import { CheckCircleTwoTone } from '@ant-design/icons';
 
@@ -13,7 +14,25 @@ export function Success(props) {
         const [links, setLinks] = useState({});
 
         const addLinks = () => {
-            console.log(links);
+            const linksArray = Object.entries(links);
+            const requestPromises = [];
+
+            linksArray.forEach(([className, meetingID]) => {
+                const splitName = className.split('-');
+                const course = splitName[0];
+                const section = splitName[1];
+
+                // Replace dashes in meeting IDs
+                const zoomLink = `https://cornell.zoom.us/j/${meetingID.replace(/-/g,'')}`;
+
+                requestPromises.push(axios.get(`/api/addLink?course=${course}&section=${section}&link=${zoomLink}`));
+            })
+
+            Promise.all(requestPromises).then(res => {
+                console.log("Added links");
+            }).catch(err => {
+                console.log(err);
+            })
         }
 
         return (
@@ -29,7 +48,7 @@ export function Success(props) {
                 form={form}
                 {...completeLayout}
                 name="addLinks"
-                onFinish={() => addLinks}
+                onFinish={addLinks}
             >
             <Form.Item>We identified classes in your schedule that we don't currently have Zoom links for. Save your Zoom meeting IDs so we can send them to you before classes!</Form.Item>
             <Form.Item>

--- a/client/src/components/Success.js
+++ b/client/src/components/Success.js
@@ -24,16 +24,20 @@ export function Success(props) {
                     const course = splitName[0];
                     const section = splitName[1];
 
-                    // Replace dashes in meeting IDs
-                    const zoomLink = `https://cornell.zoom.us/j/${meetingID.replace(/-/g,'')}`;
-
-                    requestPromises.push(axios.get(`/api/addLink?course=${course}&section=${section}&link=${zoomLink}`));
+                    // Account for errors where the meetingid is empty
+                    if (meetingID.length > 0) {
+                        // Replace dashes in meeting IDs
+                        const zoomLink = `https://cornell.zoom.us/j/${meetingID.replace(/-/g,'')}`;
+                        requestPromises.push(axios.get(`/api/addLink?course=${course}&section=${section}&link=${zoomLink}`));
+                    }
                 })
 
                 Promise.all(requestPromises).then(res => {
                     // Hide after clicking button and success
                     props.hideSuccess();
-                    Message.success(`Successfully added links to ${linksArray.length} ${linksArray.length === 1 ? 'class' : 'classes'}`);
+                    Message.success(`Successfully added links to ${requestPromises.length} ${requestPromises.length === 1 ? 'class' : 'classes'}`);
+                    // Clear links
+                    setLinks({});
                 }).catch(err => {
                     Message.error(`Unable to add links right now. Try again later`);
                     console.log(err);

--- a/client/src/components/Success.js
+++ b/client/src/components/Success.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Form, Input, Tooltip, Modal } from 'antd';
+import { CheckCircleTwoTone } from '@ant-design/icons';
+
+const completeLayout = {
+    labelCol: { span: 24 },
+    wrapperCol: { span: 24 },
+};
+
+export function Success(props) {
+
+        const [form] = Form.useForm();
+        const [links, setLinks] = useState({});
+
+        const addLinks = () => {
+            console.log(links);
+        }
+
+        return (
+            <Modal
+                visible={props.visible}
+                title={<span><CheckCircleTwoTone twoToneColor="#52c41a" /> Successfully signed up with hyw2@cornell.edu</span>}
+                cancelText= "Skip"
+                okText= 'Save'
+                onOk={() => form.submit()}
+                onCancel={props.hideSuccess}
+            >
+            <Form
+                form={form}
+                {...completeLayout}
+                name="addLinks"
+                onFinish={() => addLinks}
+            >
+            <Form.Item>We identified classes in your schedule that we don't currently have Zoom links for. Save your Zoom meeting IDs so we can send them to you before classes!</Form.Item>
+            <Form.Item>
+            <Tooltip title={<span>Access your class on <a href="https://canvas.cornell.edu/" target="_blank">Canvas</a> > Zoom > Meeting ID (e.g. 982-252-173)</span>}>
+                <strong>How do I get my Zoom meeting IDs?</strong>
+            </Tooltip>
+            </Form.Item>
+            { props.classes.map((classInfo) => {
+                return (
+                <Form.Item
+                label={`${classInfo.course} - ${classInfo.section}`}
+                name={`${classInfo.course}-${classInfo.section}`}
+                rules={[{ required: true, message: 'Please input your username!' }]}
+                >
+                <Input 
+                    onChange={(e) => setLinks({...links, [`${classInfo.course}-${classInfo.section}`]: e.target.value })}
+                />
+                </Form.Item>
+            )}) }
+
+        </Form>
+        </Modal>
+        );
+}
+
+export default Success;

--- a/client/src/components/Success.js
+++ b/client/src/components/Success.js
@@ -32,7 +32,7 @@ export function Success(props) {
                 Promise.all(requestPromises).then(res => {
                     // Hide after clicking button and success
                     props.hideSuccess();
-                    Message.success(`Successfully added links to ${linksArray.length} classes`);
+                    Message.success(`Successfully added links to ${linksArray.length} ${linksArray.length === 1 ? 'Class' : 'Classes'}`);
                 }).catch(err => {
                     Message.error(`Unable to add links right now. Try again later`);
                     console.log(err);
@@ -46,6 +46,8 @@ export function Success(props) {
             <Modal
                 visible={props.visible}
                 title={<span><CheckCircleTwoTone twoToneColor="#52c41a" /> Successfully signed up with {props.email}</span>}
+                closable={false}
+                maskClosable={false}
                 cancelText= "No Thanks"
                 okText= 'Save'
                 onOk={() => form.submit()}
@@ -68,8 +70,16 @@ export function Success(props) {
                 <Form.Item
                 label={`${classInfo.course} - ${classInfo.section}`}
                 name={`${classInfo.course}-${classInfo.section}`}
+                rules={[
+                    {
+                      pattern: /\d{9,13}/gi,
+                      message: 'Please enter a valid Zoom meeting ID',
+                    },
+                  ]}
                 >
                 <Input 
+                    placeholder="9 - 11 digit meeting ID"
+                    type="number"
                     onChange={(e) => setLinks({...links, [`${classInfo.course}-${classInfo.section}`]: e.target.value })}
                 />
                 </Form.Item>

--- a/client/src/components/Success.js
+++ b/client/src/components/Success.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
-import { Form, Input, Tooltip, Modal } from 'antd';
+import { Form, Input, Tooltip, Modal, message as Message } from 'antd';
 import { CheckCircleTwoTone } from '@ant-design/icons';
 
 const completeLayout = {
@@ -15,31 +15,38 @@ export function Success(props) {
 
         const addLinks = () => {
             const linksArray = Object.entries(links);
-            const requestPromises = [];
+            if (linksArray.length > 0) {
+                const requestPromises = [];
 
-            linksArray.forEach(([className, meetingID]) => {
-                const splitName = className.split('-');
-                const course = splitName[0];
-                const section = splitName[1];
+                linksArray.forEach(([className, meetingID]) => {
+                    const splitName = className.split('-');
+                    const course = splitName[0];
+                    const section = splitName[1];
 
-                // Replace dashes in meeting IDs
-                const zoomLink = `https://cornell.zoom.us/j/${meetingID.replace(/-/g,'')}`;
+                    // Replace dashes in meeting IDs
+                    const zoomLink = `https://cornell.zoom.us/j/${meetingID.replace(/-/g,'')}`;
 
-                requestPromises.push(axios.get(`/api/addLink?course=${course}&section=${section}&link=${zoomLink}`));
-            })
+                    requestPromises.push(axios.get(`/api/addLink?course=${course}&section=${section}&link=${zoomLink}`));
+                })
 
-            Promise.all(requestPromises).then(res => {
-                console.log("Added links");
-            }).catch(err => {
-                console.log(err);
-            })
+                Promise.all(requestPromises).then(res => {
+                    // Hide after clicking button and success
+                    props.hideSuccess();
+                    Message.success(`Successfully added links to ${linksArray.length} classes`);
+                }).catch(err => {
+                    Message.error(`Unable to add links right now. Try again later`);
+                    console.log(err);
+                })
+            } else {
+                Message.info(`At least one link is required to save`);
+            }
         }
 
         return (
             <Modal
                 visible={props.visible}
-                title={<span><CheckCircleTwoTone twoToneColor="#52c41a" /> Successfully signed up with hyw2@cornell.edu</span>}
-                cancelText= "Skip"
+                title={<span><CheckCircleTwoTone twoToneColor="#52c41a" /> Successfully signed up with {props.email}</span>}
+                cancelText= "No Thanks"
                 okText= 'Save'
                 onOk={() => form.submit()}
                 onCancel={props.hideSuccess}
@@ -61,7 +68,6 @@ export function Success(props) {
                 <Form.Item
                 label={`${classInfo.course} - ${classInfo.section}`}
                 name={`${classInfo.course}-${classInfo.section}`}
-                rules={[{ required: true, message: 'Please input your username!' }]}
                 >
                 <Input 
                     onChange={(e) => setLinks({...links, [`${classInfo.course}-${classInfo.section}`]: e.target.value })}

--- a/db-functions.js
+++ b/db-functions.js
@@ -109,7 +109,7 @@ function handleNewLink(course, section, link) {
   return new Promise(async (resolve, reject) => {
 
     const courseRef = await db.collection('zoomLinks').doc(course);
-    courseRef.update({[section]: link}).then((res) => {
+    courseRef.set({[section]: link}, {merge: true}).then((res) => {
       resolve(res);
     }).catch((err) => {
       reject(err);

--- a/db-functions.js
+++ b/db-functions.js
@@ -4,7 +4,6 @@ let emailUtil = require('./functions/email/email-user.ts')
 
 const db = firebase.admin.firestore();
 
-
 const insertData = (collectionsRef, time, email, docData) => {
   return new Promise((resolve, reject) => {
     let docRef = collectionsRef.doc(time)
@@ -82,6 +81,18 @@ function handleFormSubmission(email, id) {
   })
 }
 
+function handleNewLink(course, section, link) {
+  return new Promise(async (resolve, reject) => {
+
+    const courseRef = await db.collection('zoomLinks').doc(course);
+    courseRef.update({[section]: link}).then((res) => {
+      resolve(res);
+    }).catch((err) => {
+      reject(err);
+    });
+  })
+}
+
 function deleteUser(email) {
   return new Promise((resolve, reject) => {
     db
@@ -143,6 +154,7 @@ function deleteClassForUser(email, classCode, classSection) {
 module.exports = {
   insertData,
   handleFormSubmission,
+  handleNewLink,
   deleteUser,
   deleteClassForUser
 }

--- a/server.js
+++ b/server.js
@@ -17,9 +17,10 @@ app.get('/api/schedule', (req, res) => {
     } = req.query;
     functions
         .handleFormSubmission(email, id)
-        .then((status) =>
+        .then((unlinkedClasses) =>
             res.send({
-                success: status,
+                success: true,
+                unlinkedClasses
             })
         )
         .catch((error) =>

--- a/server.js
+++ b/server.js
@@ -30,6 +30,21 @@ app.get('/api/schedule', (req, res) => {
         );
 });
 
+app.get('/api/addLink', (req, res) => {
+    const {
+        course,
+        section,
+        link
+    } = req.query;
+    functions.handleNewLink(course, section, link)
+        .then((res) => {
+            res.send({success: true, message: res})
+        })
+        .catch((err) => {
+            res.send({success: false, message: err})
+        });
+})
+
 app.get('/api/delete-user', (req, res) => {
     const {
         email


### PR DESCRIPTION
Now, after registration, the user is prompted with a modal where they have the option to add links to courses that are currently missing links. 
In this PR, I:
- [x] added the client-side view of the modal in Success.js
- [x] added a new API endpoint to add new links
- [x] enabled additional features to the scheduler endpoint to throw back courses that (after cross-referencing) we do not have links for

<img width="827" alt="Screen Shot 2020-04-18 at 12 05 52 PM" src="https://user-images.githubusercontent.com/44352119/79642705-21666b00-816d-11ea-8c61-2ece503fa9e7.png">
